### PR TITLE
Node for admins or builders can edit terrain in safezone or warzone

### DIFF
--- a/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
@@ -326,9 +326,16 @@ public class EagleFactions
 
         //Add admin command
         Subcommands.put(Arrays.asList("admin"), CommandSpec.builder()
-                .description(Text.of("admin"))
+                .description(Text.of("Toggle admin mode"))
                 .permission("eaglefactions.command.admin")
                 .executor(new AdminCommand())
+                .build());
+
+        //Add Coords Command
+        Subcommands.put(Arrays.asList("coords"), CommandSpec.builder()
+                .description(Text.of("Show your teammates coords"))
+                .permission("eaglefactions.command.coords")
+                .executor(new CoordsCommand())
                 .build());
 
         //Build all commands

--- a/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
@@ -342,6 +342,7 @@ public class EagleFactions
         Subcommands.put(Arrays.asList("setpower"), CommandSpec.builder()
                 .description(Text.of("Set player's power"))
                 .permission("eaglefactions.command.setpower")
+                .arguments(GenericArguments.onlyOne(GenericArguments.player(Text.of("player"))), GenericArguments.remainingJoinedStrings(Text.of("power")))
                 .executor(new SetPowerCommand())
                 .build());
 
@@ -357,7 +358,6 @@ public class EagleFactions
         CommandSpec commandEagleFactions = CommandSpec.builder ()
                 .description (Text.of ("Help Command"))
                 .permission ("eaglefactions.command")
-                .arguments(GenericArguments.onlyOne(GenericArguments.player(Text.of("player"))), GenericArguments.remainingJoinedStrings(Text.of("power")))
                 .executor (new HelpCommand())
                 .children (Subcommands)
                 .build ();

--- a/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
@@ -345,6 +345,14 @@ public class EagleFactions
                 .executor(new SetPowerCommand())
                 .build());
 
+        //Add MaxPower Command
+        Subcommands.put(Arrays.asList("maxpower"), CommandSpec.builder()
+                .description(Text.of("Set player's maxpower"))
+                .permission("eaglefactions.command.maxpower")
+                .arguments(GenericArguments.onlyOne(GenericArguments.player(Text.of("player"))), GenericArguments.remainingJoinedStrings(Text.of("power")))
+                .executor(new MaxPowerCommand())
+                .build());
+
         //Build all commands
         CommandSpec commandEagleFactions = CommandSpec.builder ()
                 .description (Text.of ("Help Command"))

--- a/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
@@ -300,7 +300,7 @@ public class EagleFactions
         Subcommands.put(Arrays.asList("sethome"), CommandSpec.builder()
                 .description(Text.of("Set faction's home"))
                 .permission("eaglefactions.command.sethome")
-                .executor(new SethomeCommand())
+                .executor(new SetHomeCommand())
                 .build());
 
         //Home command
@@ -336,6 +336,13 @@ public class EagleFactions
                 .description(Text.of("Show your teammates coords"))
                 .permission("eaglefactions.command.coords")
                 .executor(new CoordsCommand())
+                .build());
+
+        //Add SetPower Command
+        Subcommands.put(Arrays.asList("setpower"), CommandSpec.builder()
+                .description(Text.of("Set player's power"))
+                .permission("eaglefactions.command.setpower")
+                .executor(new SetPowerCommand())
                 .build());
 
         //Build all commands

--- a/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
@@ -349,6 +349,7 @@ public class EagleFactions
         CommandSpec commandEagleFactions = CommandSpec.builder ()
                 .description (Text.of ("Help Command"))
                 .permission ("eaglefactions.command")
+                .arguments(GenericArguments.onlyOne(GenericArguments.player(Text.of("player"))), GenericArguments.remainingJoinedStrings(Text.of("power")))
                 .executor (new HelpCommand())
                 .children (Subcommands)
                 .build ();

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/ClaimCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/ClaimCommand.java
@@ -38,7 +38,7 @@ public class ClaimCommand implements CommandExecutor
                     if(!FactionLogic.isClaimed(world.getUniqueId(), chunk))
                     {
 
-                        if(PowerService.getFactionPower(FactionLogic.getFaction(playerFactionName)).doubleValue() >= FactionLogic.getClaims(playerFactionName).size())
+                        if(PowerService.getFactionPower(playerFactionName).doubleValue() >= FactionLogic.getClaims(playerFactionName).size())
                         {
                             if(!FactionLogic.getClaims(playerFactionName).isEmpty())
                             {

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/CoordsCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/CoordsCommand.java
@@ -1,0 +1,111 @@
+package io.github.aquerr.eaglefactions.commands;
+
+import io.github.aquerr.eaglefactions.PluginInfo;
+import io.github.aquerr.eaglefactions.logic.FactionLogic;
+import io.github.aquerr.eaglefactions.services.PlayerService;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.service.pagination.PaginationList;
+import org.spongepowered.api.service.pagination.PaginationService;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class CoordsCommand
+{
+    public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
+    {
+        if(source instanceof Player)
+        {
+            Player player = (Player)source;
+
+            String factionName = FactionLogic.getFactionName(player.getUniqueId());
+
+            List<Text> teamCoords = new ArrayList<>();
+
+            if(factionName != null)
+            {
+                if(FactionLogic.getHome(factionName) != null)
+                {
+                    Text textBuilder = Text.builder()
+                            .append(Text.of("Home: " + FactionLogic.getHome(factionName).toString()))
+                            .build();
+
+                    teamCoords.add(textBuilder);
+                }
+
+                if (!FactionLogic.getLeader(factionName).equals(""))
+                {
+                    Optional<Player> leader = PlayerService.getPlayer(UUID.fromString(FactionLogic.getLeader(factionName)));
+
+                    if(leader.isPresent())
+                    {
+                        Text textBuilder = Text.builder()
+                                .append(Text.of("Leader: " + leader.get().getName() + " " + leader.get().getLocation().getBlockPosition().toString()))
+                                .build();
+
+                        teamCoords.add(textBuilder);
+                    }
+                }
+
+                if(!FactionLogic.getOfficers(factionName).isEmpty())
+                {
+                    for (String officerName: FactionLogic.getOfficers(factionName))
+                    {
+                        Optional<Player> officer = PlayerService.getPlayer(UUID.fromString(officerName));
+
+                        if(officer.isPresent())
+                        {
+                            Text textBuilder = Text.builder()
+                                    .append(Text.of("Officer: " + officer.get().getName() + " " + officer.get().getLocation().getBlockPosition().toString()))
+                                    .build();
+
+                            teamCoords.add(textBuilder);
+                        }
+                    }
+                }
+
+                if(!FactionLogic.getMembers(factionName).isEmpty())
+                {
+                    for (String memberName: FactionLogic.getMembers(factionName))
+                    {
+                        Optional<Player> member = PlayerService.getPlayer(UUID.fromString(memberName));
+
+                        if(member.isPresent())
+                        {
+                            Text textBuilder = Text.builder()
+                                    .append(Text.of("Officer: " + member.get().getName() + " " + member.get().getLocation().getBlockPosition().toString()))
+                                    .build();
+
+                            teamCoords.add(textBuilder);
+                        }
+                    }
+                }
+
+                PaginationService paginationService = Sponge.getServiceManager().provide(PaginationService.class).get();
+                PaginationList.Builder paginationBuilder = paginationService.builder().title(Text.of(TextColors.GREEN, "Faction Coords")).contents(teamCoords);
+                paginationBuilder.sendTo(source);
+
+            }
+            else
+            {
+                source.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "You must be in a faction in order to use this command!"));
+            }
+
+        }
+        else
+        {
+            source.sendMessage (Text.of (PluginInfo.ErrorPrefix, TextColors.RED, "Only in-game players can use this command!"));
+        }
+
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/CoordsCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/CoordsCommand.java
@@ -92,7 +92,7 @@ public class CoordsCommand implements CommandExecutor
                 }
 
                 PaginationService paginationService = Sponge.getServiceManager().provide(PaginationService.class).get();
-                PaginationList.Builder paginationBuilder = paginationService.builder().title(Text.of(TextColors.GREEN, "Faction Coords")).contents(teamCoords);
+                PaginationList.Builder paginationBuilder = paginationService.builder().title(Text.of(TextColors.GREEN, "Team Coords")).contents(teamCoords);
                 paginationBuilder.sendTo(source);
 
             }

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/CoordsCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/CoordsCommand.java
@@ -8,6 +8,7 @@ import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.service.pagination.PaginationList;
 import org.spongepowered.api.service.pagination.PaginationService;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public class CoordsCommand
+public class CoordsCommand implements CommandExecutor
 {
     public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
     {

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/HelpCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/HelpCommand.java
@@ -29,7 +29,6 @@ public class HelpCommand implements CommandExecutor
 
         for (List<String> aliases: commands.keySet())
         {
-            //Add sorting on aliases.
             CommandSpec commandSpec = commands.get(aliases);
 
             Text commandHelp = Text.builder()
@@ -45,13 +44,11 @@ public class HelpCommand implements CommandExecutor
             helpList.add(commandHelp);
         }
 
-        //Sort commands alphabetically
+        //Sort commands alphabetically.
         helpList.sort(Text::compareTo);
 
-        //Collections.sort(helpList);
-
         PaginationService paginationService = Sponge.getServiceManager().provide(PaginationService.class).get();
-        PaginationList.Builder paginationBuilder = paginationService.builder().title(Text.of(TextColors.GREEN, "EagleFactions Command List")).padding(Text.of("-")).contents(helpList);
+        PaginationList.Builder paginationBuilder = paginationService.builder().title(Text.of(TextColors.GREEN, "EagleFactions Command List")).padding(Text.of("-")).contents(helpList).linesPerPage(10);
         paginationBuilder.sendTo(source);
 
         return CommandResult.success ();

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/HelpCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/HelpCommand.java
@@ -43,6 +43,9 @@ public class HelpCommand implements CommandExecutor
             helpList.add(commandHelp);
         }
 
+        //Sort commands alphabetically
+        helpList.sort(Text::compareTo);
+
         PaginationService paginationService = Sponge.getServiceManager().provide(PaginationService.class).get();
         PaginationList.Builder paginationBuilder = paginationService.builder().title(Text.of(TextColors.GREEN, "EagleFactions Command List")).padding(Text.of("-")).contents(helpList);
         paginationBuilder.sendTo(source);

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/HelpCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/HelpCommand.java
@@ -15,6 +15,7 @@ import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ public class HelpCommand implements CommandExecutor
 
         for (List<String> aliases: commands.keySet())
         {
+            //Add sorting on aliases.
             CommandSpec commandSpec = commands.get(aliases);
 
             Text commandHelp = Text.builder()
@@ -45,6 +47,8 @@ public class HelpCommand implements CommandExecutor
 
         //Sort commands alphabetically
         helpList.sort(Text::compareTo);
+
+        //Collections.sort(helpList);
 
         PaginationService paginationService = Sponge.getServiceManager().provide(PaginationService.class).get();
         PaginationList.Builder paginationBuilder = paginationService.builder().title(Text.of(TextColors.GREEN, "EagleFactions Command List")).padding(Text.of("-")).contents(helpList);

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/HomeCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/HomeCommand.java
@@ -2,6 +2,7 @@ package io.github.aquerr.eaglefactions.commands;
 
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
+import io.github.aquerr.eaglefactions.EagleFactions;
 import io.github.aquerr.eaglefactions.PluginInfo;
 import io.github.aquerr.eaglefactions.logic.FactionLogic;
 import org.spongepowered.api.command.CommandException;
@@ -37,8 +38,11 @@ public class HomeCommand implements CommandExecutor
 
                     if(FactionLogic.isHomeInWorld(world.getUniqueId(), playerFactionName))
                     {
+                        EagleFactions.getEagleFactions().getLogger().info("Found home!!!");
+
                         Vector3i home = FactionLogic.getHome(playerFactionName);
 
+                        EagleFactions.getEagleFactions().getLogger().info("Teleporting the player...");
                         player.setLocation(player.getLocation().setBlockPosition(home));
 
                         source.sendMessage(Text.of(PluginInfo.PluginPrefix, "You were teleported to faction's home"));

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/HomeCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/HomeCommand.java
@@ -1,6 +1,7 @@
 package io.github.aquerr.eaglefactions.commands;
 
 import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
 import io.github.aquerr.eaglefactions.PluginInfo;
 import io.github.aquerr.eaglefactions.logic.FactionLogic;
 import org.spongepowered.api.command.CommandException;
@@ -32,9 +33,9 @@ public class HomeCommand implements CommandExecutor
                 {
                     //TODO: Wait 5-10 seconds before teleport.
 
-                    Vector3d home = FactionLogic.getHome(playerFactionName);
+                    Vector3i home = FactionLogic.getHome(playerFactionName);
                     
-                    player.setLocation(player.getLocation().setPosition(home));
+                    player.setLocation(player.getLocation().setBlockPosition(home));
 
                     source.sendMessage(Text.of(PluginInfo.PluginPrefix, "You were teleported to faction's home"));
                 }

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/ListCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/ListCommand.java
@@ -1,6 +1,8 @@
 package io.github.aquerr.eaglefactions.commands;
 
+import io.github.aquerr.eaglefactions.entities.Faction;
 import io.github.aquerr.eaglefactions.logic.FactionLogic;
+import io.github.aquerr.eaglefactions.services.PowerService;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
@@ -21,14 +23,17 @@ public class ListCommand implements CommandExecutor
     @Override
     public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
     {
-        HashSet<Object> factionsList = new HashSet<>(FactionLogic.getFactionsNames());
+        HashSet<Faction> factionsList = new HashSet<>(FactionLogic.getFactions());
         List<Text> helpList = new ArrayList<>();
 
-        for(Object faction: factionsList)
+        for(Faction faction: factionsList)
         {
+            String tag = "";
+            if(faction.Tag != null && !faction.Tag.equals("")) tag = "[" + faction.Tag + "] ";
+
             Text factionHelp = Text.builder()
                     .append(Text.builder()
-                            .append(Text.of(TextColors.AQUA, "- " + faction.toString()))
+                            .append(Text.of(TextColors.AQUA, "- " + tag + faction.Name + "(" + faction.Power + "/" + PowerService.getFactionMaxPower(faction) + ")"))
                             .build())
                     .build();
 

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/ListCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/ListCommand.java
@@ -33,7 +33,7 @@ public class ListCommand implements CommandExecutor
 
             Text factionHelp = Text.builder()
                     .append(Text.builder()
-                            .append(Text.of(TextColors.AQUA, "- " + tag + faction.Name + "(" + faction.Power + "/" + PowerService.getFactionMaxPower(faction) + ")"))
+                            .append(Text.of(TextColors.AQUA, "- " + tag + faction.Name + " (" + faction.Power + "/" + PowerService.getFactionMaxPower(faction) + ")"))
                             .build())
                     .build();
 

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/MaxPowerCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/MaxPowerCommand.java
@@ -12,7 +12,6 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
-import javax.swing.text.html.Option;
 import java.math.BigDecimal;
 import java.util.Optional;
 
@@ -22,7 +21,7 @@ public class MaxPowerCommand implements CommandExecutor
     public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
     {
         Optional<Player> selectedPlayer = context.<Player>getOne(Text.of("player"));
-        Optional<BigDecimal> power = context.<BigDecimal>getOne(Text.of("power"));
+        Optional<String> power = context.<String>getOne(Text.of("power"));
 
         if(source instanceof Player)
         {
@@ -32,9 +31,11 @@ public class MaxPowerCommand implements CommandExecutor
             {
                 if(power.isPresent())
                 {
-                    if(EagleFactions.AdminList.contains(player.getUniqueId()))
+                    if(EagleFactions.AdminList.contains(player.getUniqueId().toString()))
                     {
-                        PowerService.setMaxPower(selectedPlayer.get().getUniqueId(), power.get());
+                        BigDecimal newPower = new BigDecimal(power.get());
+
+                        PowerService.setMaxPower(selectedPlayer.get().getUniqueId(), newPower);
 
                         player.sendMessage(Text.of(PluginInfo.PluginPrefix, TextColors.GREEN, "Player's maxpower has been changed!"));
                         return CommandResult.success();

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/MaxPowerCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/MaxPowerCommand.java
@@ -1,6 +1,5 @@
 package io.github.aquerr.eaglefactions.commands;
 
-import com.flowpowered.noise.module.combiner.Power;
 import io.github.aquerr.eaglefactions.EagleFactions;
 import io.github.aquerr.eaglefactions.PluginInfo;
 import io.github.aquerr.eaglefactions.services.PowerService;
@@ -13,38 +12,48 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
+import javax.swing.text.html.Option;
 import java.math.BigDecimal;
+import java.util.Optional;
 
-public class SetPowerCommand implements CommandExecutor
+public class MaxPowerCommand implements CommandExecutor
 {
     @Override
     public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
     {
-        Player selectedPlayer = context.<Player>getOne("player").get();
-        BigDecimal power = context.<BigDecimal>getOne("power").get();
+        Optional<Player> selectedPlayer = context.<Player>getOne(Text.of("player"));
+        Optional<BigDecimal> power = context.<BigDecimal>getOne(Text.of("power"));
 
         if(source instanceof Player)
         {
             Player player = (Player)source;
 
-            if(EagleFactions.AdminList.contains(player.getUniqueId().toString()))
+            if(selectedPlayer.isPresent())
             {
-                if(selectedPlayer != null)
+                if(power.isPresent())
                 {
-                    PowerService.setPower(selectedPlayer.getUniqueId(), power);
+                    if(EagleFactions.AdminList.contains(player.getUniqueId()))
+                    {
+                        PowerService.setMaxPower(selectedPlayer.get().getUniqueId(), power.get());
 
-                    player.sendMessage(Text.of(PluginInfo.PluginPrefix, TextColors.GREEN, "Player's power has been changed!"));
-                    return CommandResult.success();
+                        player.sendMessage(Text.of(PluginInfo.PluginPrefix, TextColors.GREEN, "Player's maxpower has been changed!"));
+                        return CommandResult.success();
+                    }
+                    else
+                    {
+                        player.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "You need to toggle faction admin mode to do this!"));
+                    }
                 }
                 else
                 {
-                    player.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "There is no such player."));
+                    player.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "You did not assign power!"));
                 }
             }
             else
             {
-                player.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "You need to toggle faction admin mode to do this!"));
+                player.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "There is no such player."));
             }
+
         }
         else
         {

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/PlayerCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/PlayerCommand.java
@@ -16,6 +16,7 @@ import org.spongepowered.api.service.pagination.PaginationService;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,7 +43,7 @@ public class PlayerCommand implements CommandExecutor
 
             Text info = Text.builder()
                     .append(Text.of(TextColors.AQUA, "Name: ", TextColors.GOLD, PlayerService.getPlayerName(player.getUniqueId()).get() + "\n"))
-                    .append(Text.of(TextColors.AQUA, "Last Played: ", TextColors.GOLD, player.getJoinData().lastPlayed().get() + "\n"))
+                    .append(Text.of(TextColors.AQUA, "Last Played: ", TextColors.GOLD, Date.from(player.getJoinData().lastPlayed().get()) + "\n"))
                     .append(Text.of(TextColors.AQUA, "Faction: ", TextColors.GOLD, playerFactionName + "\n"))
                     .append(Text.of(TextColors.AQUA, "Power: ", TextColors.GOLD, PowerService.getPlayerPower(player.getUniqueId()) + "/" + PowerService.getPlayerMaxPower(player.getUniqueId())))
                     .build();

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/SetHomeCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/SetHomeCommand.java
@@ -14,7 +14,7 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.world.World;
 
-public class SethomeCommand implements CommandExecutor
+public class SetHomeCommand implements CommandExecutor
 {
     @Override
     public CommandResult execute(CommandSource source, CommandContext context) throws CommandException

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/SetPowerCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/SetPowerCommand.java
@@ -14,14 +14,15 @@ import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 public class SetPowerCommand implements CommandExecutor
 {
     @Override
     public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
     {
-        Player selectedPlayer = context.<Player>getOne("player").get();
-        BigDecimal power = context.<BigDecimal>getOne("power").get();
+        Optional<Player> selectedPlayer = context.<Player>getOne("player");
+        Optional<BigDecimal> power = context.<BigDecimal>getOne("power");
 
         if(source instanceof Player)
         {
@@ -31,10 +32,17 @@ public class SetPowerCommand implements CommandExecutor
             {
                 if(selectedPlayer != null)
                 {
-                    PowerService.setPower(selectedPlayer.getUniqueId(), power);
+                    if(power.isPresent())
+                    {
+                        PowerService.setPower(selectedPlayer.get().getUniqueId(), power.get());
 
-                    player.sendMessage(Text.of(PluginInfo.PluginPrefix, TextColors.GREEN, "Player's power has been changed!"));
-                    return CommandResult.success();
+                        player.sendMessage(Text.of(PluginInfo.PluginPrefix, TextColors.GREEN, "Player's power has been changed!"));
+                        return CommandResult.success();
+                    }
+                    else
+                    {
+
+                    }
                 }
                 else
                 {

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/SetPowerCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/SetPowerCommand.java
@@ -1,0 +1,56 @@
+package io.github.aquerr.eaglefactions.commands;
+
+import com.flowpowered.noise.module.combiner.Power;
+import io.github.aquerr.eaglefactions.EagleFactions;
+import io.github.aquerr.eaglefactions.PluginInfo;
+import io.github.aquerr.eaglefactions.services.PowerService;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.math.BigDecimal;
+
+public class SetPowerCommand implements CommandExecutor
+{
+    @Override
+    public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
+    {
+        Player selectedPlayer = context.<Player>getOne("player").get();
+        BigDecimal power = context.<BigDecimal>getOne("power").get();
+
+        if(source instanceof Player)
+        {
+            Player player = (Player)source;
+
+            if(EagleFactions.AdminList.contains(player.getUniqueId().toString()))
+            {
+                if(selectedPlayer != null)
+                {
+                    PowerService.setPower(selectedPlayer.getUniqueId(), power);
+
+                    player.sendMessage(Text.of(PluginInfo.PluginPrefix, TextColors.GREEN, "Players power has been set!"));
+                    return CommandResult.success();
+                }
+                else
+                {
+                    player.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "There is no such player."));
+                }
+            }
+            else
+            {
+                player.sendMessage(Text.of(PluginInfo.ErrorPrefix, TextColors.RED, "You need to toggle faction admin mode to do this!"));
+            }
+        }
+        else
+        {
+            source.sendMessage (Text.of (PluginInfo.ErrorPrefix, TextColors.RED, "Only in-game players can use this command!"));
+        }
+
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/SetPowerCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/SetPowerCommand.java
@@ -1,6 +1,5 @@
 package io.github.aquerr.eaglefactions.commands;
 
-import com.flowpowered.noise.module.combiner.Power;
 import io.github.aquerr.eaglefactions.EagleFactions;
 import io.github.aquerr.eaglefactions.PluginInfo;
 import io.github.aquerr.eaglefactions.services.PowerService;
@@ -22,7 +21,7 @@ public class SetPowerCommand implements CommandExecutor
     public CommandResult execute(CommandSource source, CommandContext context) throws CommandException
     {
         Optional<Player> selectedPlayer = context.<Player>getOne("player");
-        Optional<BigDecimal> power = context.<BigDecimal>getOne("power");
+        Optional<String> power = context.<String>getOne("power");
 
         if(source instanceof Player)
         {
@@ -34,7 +33,9 @@ public class SetPowerCommand implements CommandExecutor
                 {
                     if(power.isPresent())
                     {
-                        PowerService.setPower(selectedPlayer.get().getUniqueId(), power.get());
+                        BigDecimal newPower = new BigDecimal(power.get());
+
+                        PowerService.setPower(selectedPlayer.get().getUniqueId(), newPower);
 
                         player.sendMessage(Text.of(PluginInfo.PluginPrefix, TextColors.GREEN, "Player's power has been changed!"));
                         return CommandResult.success();

--- a/src/main/java/io/github/aquerr/eaglefactions/commands/SethomeCommand.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/commands/SethomeCommand.java
@@ -1,6 +1,7 @@
 package io.github.aquerr.eaglefactions.commands;
 
 import com.flowpowered.math.vector.Vector3d;
+import com.flowpowered.math.vector.Vector3i;
 import io.github.aquerr.eaglefactions.PluginInfo;
 import io.github.aquerr.eaglefactions.logic.FactionLogic;
 import org.spongepowered.api.command.CommandException;
@@ -32,7 +33,7 @@ public class SethomeCommand implements CommandExecutor
 
                     if(FactionLogic.isClaimed(world.getUniqueId(), player.getLocation().getChunkPosition()))
                     {
-                        Vector3d home = new Vector3d(player.getLocation().getPosition());
+                        Vector3i home = new Vector3i(player.getLocation().getBlockPosition());
 
                         FactionLogic.setHome(playerFactionName, home);
                         source.sendMessage(Text.of(PluginInfo.PluginPrefix, "Faction home has been set!"));

--- a/src/main/java/io/github/aquerr/eaglefactions/config/MainConfig.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/config/MainConfig.java
@@ -89,11 +89,12 @@ public class MainConfig implements IConfig
         get().getNode("eaglefactions", "tag", "maxlength").setValue(5).setComment("This determines the minimum amount of characters a Factions's tag can be.");
         get().getNode("eaglefactions", "tag", "minlength").setValue(2).setComment("This determines the minimum amount of characters a Factions's tag can be.");
         get().getNode("eaglefactions", "prefix", "display").setValue(true).setComment("Allows/denies displaying Faction prefixes.");
-        get().getNode("eaglefactions", "power", "increment").setValue(0.04).setComment("How much power will be restored for player after 1 minute of playing. (0.05 per minute = 1,5 per hour");
+        get().getNode("eaglefactions", "power", "increment").setValue(0.04).setComment("How much power will be restored for player after 1 minute of playing. (0.04 per minute = 1,2 per hour");
         get().getNode("eaglefactions", "power", "decrement").setValue(2.0).setComment("How much power will be removed on player death");
         get().getNode("eaglefactions", "power", "maxpower").setValue(10.0).setComment("Maximum amount of power a player can have");
         get().getNode("eaglefactions", "power", "startpower").setValue(5.0).setComment("Starting amount of power");
         get().getNode("eaglefactions", "power", "killaward").setValue(2.0).setComment("Player kill award");
+        get().getNode("eaglefactions", "power", "punishment").setValue(1.0).setComment("Punishment after killing a teammate.");
         get().getNode("eaglefactions", "friendlyfire", "alliance").setValue(false).setComment("Allows/denies friendly fire between alliances.");
         get().getNode("eaglefactions", "spawn", "mobs").setValue(false).setComment("Allows/denies mob spawning on factions lands.");
     }

--- a/src/main/java/io/github/aquerr/eaglefactions/listeners/ChatMessageListener.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/listeners/ChatMessageListener.java
@@ -16,6 +16,8 @@ public class ChatMessageListener
     {
         if(FactionLogic.getFactionName(player.getUniqueId()) != null)
         {
+            String factionName = FactionLogic.getFactionName(player.getUniqueId());
+
           //  //Get full formatted and colored message.
           //  Text fullMessage = event.getMessage();
           //  EagleFactions.getEagleFactions().getLogger().info(fullMessage.toPlain());
@@ -66,14 +68,41 @@ public class ChatMessageListener
 //
           //  event.setMessage(messageToPrint);
 
-              //Get faction's tag
-              Text factionTag = Text.builder()
-                      .append(Text.of("[" ,TextColors.GREEN, FactionLogic.getFactionTag(FactionLogic.getFactionName(player.getUniqueId())), TextColors.RESET, "]"))
-                      .build();
-              EagleFactions.getEagleFactions().getLogger().info(factionTag.toPlain());
+            Text factionPrefix = Text.builder().build();
 
+            if(!FactionLogic.getFactionTag(factionName).equals("") || FactionLogic.getFactionTag(factionName) != null)
+            {
+                //Get faction's tag
+                Text factionTag = Text.builder()
+                        .append(Text.of("[" ,TextColors.GREEN, FactionLogic.getFactionTag(factionName), TextColors.RESET, "]"))
+                        .build();
+
+                factionPrefix.toBuilder().append(factionTag).build();
+            }
+
+            //Get leader prefix.
+            if(FactionLogic.getLeader(factionName).equals(player.getUniqueId().toString()))
+            {
+                Text leaderPrefix = Text.builder()
+                        .append(Text.of("[", TextColors.GOLD, "Leader", TextColors.RESET, "]"))
+                        .build();
+
+                factionPrefix.toBuilder().append(leaderPrefix).build();
+            }
+
+            //Get officer prefix.
+            if(FactionLogic.getOfficers(factionName).contains(player.getUniqueId().toString()))
+            {
+                Text officerPrefix = Text.builder()
+                        .append(Text.of("[", TextColors.GOLD, "Officer", TextColors.RESET, "]"))
+                        .build();
+
+                factionPrefix.toBuilder().append(officerPrefix).build();
+            }
+
+            //Build the whole message & print.
             Text messageToPrint = Text.builder()
-                    .append(factionTag)
+                    .append(factionPrefix)
                     .append(event.getMessage())
                     .build();
 

--- a/src/main/java/io/github/aquerr/eaglefactions/listeners/ChatMessageListener.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/listeners/ChatMessageListener.java
@@ -70,8 +70,10 @@ public class ChatMessageListener
 
             Text factionPrefix = Text.builder().build();
 
-            if(!FactionLogic.getFactionTag(factionName).equals("") || FactionLogic.getFactionTag(factionName) != null)
+            if(!FactionLogic.getFactionTag(factionName).equals("") && FactionLogic.getFactionTag(factionName) != null)
             {
+                EagleFactions.getEagleFactions().getLogger().info("Tag has been found!");
+
                 //Get faction's tag
                 Text factionTag = Text.builder()
                         .append(Text.of("[" ,TextColors.GREEN, FactionLogic.getFactionTag(factionName), TextColors.RESET, "]"))
@@ -83,6 +85,9 @@ public class ChatMessageListener
             //Get leader prefix.
             if(FactionLogic.getLeader(factionName).equals(player.getUniqueId().toString()))
             {
+                EagleFactions.getEagleFactions().getLogger().info("Leader has been found!");
+
+
                 Text leaderPrefix = Text.builder()
                         .append(Text.of("[", TextColors.GOLD, "Leader", TextColors.RESET, "]"))
                         .build();
@@ -93,12 +98,16 @@ public class ChatMessageListener
             //Get officer prefix.
             if(FactionLogic.getOfficers(factionName).contains(player.getUniqueId().toString()))
             {
+                EagleFactions.getEagleFactions().getLogger().info("Officer has been found!");
+
                 Text officerPrefix = Text.builder()
                         .append(Text.of("[", TextColors.GOLD, "Officer", TextColors.RESET, "]"))
                         .build();
 
                 factionPrefix.toBuilder().append(officerPrefix).build();
             }
+
+            EagleFactions.getEagleFactions().getLogger().info("Build the whole message!");
 
             //Build the whole message & print.
             Text messageToPrint = Text.builder()

--- a/src/main/java/io/github/aquerr/eaglefactions/listeners/EntityDamageListener.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/listeners/EntityDamageListener.java
@@ -64,18 +64,26 @@ public class EntityDamageListener
                                         event.setCancelled(true);
                                         return;
                                     }
-                                }//Check if players are in different factions but are in the alliance.
+                                    else
+                                    {
+                                        if(event.willCauseDeath())
+                                        {
+                                            PowerService.punish(player.getUniqueId());
+                                            return;
+                                        }
+                                    }
+                                }//Check if players are in the alliance.
                                 else if(FactionLogic.getAlliances(FactionLogic.getFactionName(player.getUniqueId())).contains(FactionLogic.getFactionName(attackedPlayer.getUniqueId())) && !MainLogic.getAllianceFriendlyFire())
                                 {
                                     event.setBaseDamage(0);
                                     event.setCancelled(true);
                                     return;
                                 }
-                                else
+                                else if(FactionLogic.getAlliances(FactionLogic.getFactionName(player.getUniqueId())).contains(FactionLogic.getFactionName(attackedPlayer.getUniqueId())) && MainLogic.getAllianceFriendlyFire())
                                 {
                                     if(event.willCauseDeath())
                                     {
-                                        PowerService.addPower(player.getUniqueId(), true);
+                                        PowerService.punish(player.getUniqueId());
                                         return;
                                     }
                                 }

--- a/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
@@ -447,8 +447,12 @@ public class FactionLogic
         if(homeNode.getValue() != null)
         {
             String homeString = homeNode.getString();
+            String splitter = "\\|";
 
-            String vectors[] = homeString.split("|")[1].replace("(", "").replace(")", "").replace(" ", "").split(",");
+          //  String worldUUID = homeString.split(splitter)[0];
+            String vectorsString = homeString.split(splitter)[1];
+
+            String vectors[] = vectorsString.replace("(", "").replace(")", "").replace(" ", "").split(",");
 
              int x = Integer.valueOf(vectors[0]);
              int y = Integer.valueOf(vectors[1]);
@@ -510,10 +514,11 @@ public class FactionLogic
 
         if(homeNode.getValue() != null)
         {
+            EagleFactions.getEagleFactions().getLogger().info("Home may be in this world...");
             if(homeNode.getString().contains(worldUUID.toString())) return true;
             else return false;
         }
-
+        EagleFactions.getEagleFactions().getLogger().info("Home is not set...");
         return false;
     }
 }

--- a/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
@@ -431,13 +431,13 @@ public class FactionLogic
         return false;
     }
 
-    public static void setHome(String factionName, @Nullable Vector3d home)
+    public static void setHome(String factionName, @Nullable Vector3i home)
     {
         if(home == null) ConfigAccess.setValueAndSave(factionsConfig, new Object[]{"factions",factionName, "home"}, home);
         else ConfigAccess.setValueAndSave(factionsConfig, new Object[]{"factions", factionName, "home"}, home.toString());
     }
 
-    public static Vector3d getHome(String factionName)
+    public static Vector3i getHome(String factionName)
     {
         ConfigurationNode homeNode = ConfigAccess.getConfig(factionsConfig).getNode("factions", factionName, "home");
 
@@ -447,11 +447,11 @@ public class FactionLogic
 
             String vectors[] = homeString.replace("(", "").replace(")", "").replace(" ", "").split(",");
 
-             double x = Double.valueOf(vectors[0]);
-             double y = Double.valueOf(vectors[1]);
-             double z = Double.valueOf(vectors[2]);
+             int x = Integer.valueOf(vectors[0]);
+             int y = Integer.valueOf(vectors[1]);
+             int z = Integer.valueOf(vectors[2]);
 
-             Vector3d home = Vector3d.from(x, y, z);
+             Vector3i home = Vector3i.from(x, y, z);
 
              return home;
         }

--- a/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
@@ -71,7 +71,6 @@ public class FactionLogic
 
     public static Faction getFaction(String factionName)
     {
-        EagleFactions.getEagleFactions().getLogger().info("Getting a faction: " + factionName);
         ConfigurationNode leaderNode = ConfigAccess.getConfig(factionsConfig).getNode("factions", factionName, "leader");
 
         String leaderUUID = "";
@@ -91,7 +90,6 @@ public class FactionLogic
         faction.Claims = getClaims(factionName);
         faction.Power = PowerService.getFactionPower(factionName);
 
-        EagleFactions.getEagleFactions().getLogger().info("Returning a faction...");
         return faction;
     }
 

--- a/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/logic/FactionLogic.java
@@ -89,7 +89,7 @@ public class FactionLogic
         faction.Enemies = getEnemies(factionName);
         faction.Alliances = getAlliances(factionName);
         faction.Claims = getClaims(factionName);
-        faction.Power = PowerService.getFactionPower(faction);
+        faction.Power = PowerService.getFactionPower(factionName);
 
         EagleFactions.getEagleFactions().getLogger().info("Returning a faction...");
         return faction;

--- a/src/main/java/io/github/aquerr/eaglefactions/logic/MainLogic.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/logic/MainLogic.java
@@ -65,6 +65,15 @@ public class MainLogic
         return killAward;
     }
 
+    public static BigDecimal getPunishment()
+    {
+        ConfigurationNode punishmentNode = ConfigAccess.getConfig(mainConfig).getNode("eaglefactions", "power", "punishment");
+
+        BigDecimal punishment = new BigDecimal(punishmentNode.getString());
+
+        return punishment;
+    }
+
     public static int getMaxNameLength()
     {
         ConfigurationNode maxLengthNode = ConfigAccess.getConfig(mainConfig).getNode("eaglefactions", "name", "maxlength");

--- a/src/main/java/io/github/aquerr/eaglefactions/services/PowerService.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/services/PowerService.java
@@ -2,6 +2,9 @@ package io.github.aquerr.eaglefactions.services;
 
 import io.github.aquerr.eaglefactions.EagleFactions;
 import io.github.aquerr.eaglefactions.PluginInfo;
+import io.github.aquerr.eaglefactions.config.ConfigAccess;
+import io.github.aquerr.eaglefactions.config.FactionsConfig;
+import io.github.aquerr.eaglefactions.config.IConfig;
 import io.github.aquerr.eaglefactions.entities.Faction;
 import io.github.aquerr.eaglefactions.logic.MainLogic;
 import ninja.leaping.configurate.ConfigurationNode;
@@ -26,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 
 public class PowerService
 {
+    private static IConfig factionsConfig = FactionsConfig.getConfig();
+
     public static boolean checkIfPlayerExists(UUID playerUUID)
     {
         Path playerFile = Paths.get(EagleFactions.getEagleFactions ().getConfigDir().resolve("players") +  "/" + playerUUID.toString() + ".conf");
@@ -92,32 +97,36 @@ public class PowerService
         return BigDecimal.ZERO;
     }
 
-    public static BigDecimal getFactionPower(Faction faction)
+    public static BigDecimal getFactionPower(String factionName)
     {
-        BigDecimal factionPower = BigDecimal.ZERO;
+        ConfigurationNode powerNode = ConfigAccess.getConfig(factionsConfig).getNode("factions", factionName, "power");
 
-        if(faction.Leader != null && faction.Leader != "")
-        {
-            factionPower = factionPower.add(getPlayerPower(UUID.fromString(faction.Leader)));
-        }
+        BigDecimal factionPower = new BigDecimal(powerNode.getDouble());
 
-        if(faction.Officers != null && !faction.Officers.isEmpty())
-        {
-            for (String officer: faction.Officers)
-            {
-                BigDecimal officerPower = getPlayerPower(UUID.fromString(officer));
-                factionPower =factionPower.add(officerPower);
-            }
-        }
-
-        if(faction.Members != null && !faction.Members.isEmpty())
-        {
-            for (String member: faction.Members)
-            {
-                BigDecimal memberPower = getPlayerPower(UUID.fromString(member));
-                factionPower = factionPower.add(memberPower);
-            }
-        }
+       // BigDecimal factionPower = BigDecimal.ZERO;
+//
+       // if(faction.Leader != null && faction.Leader != "")
+       // {
+       //     factionPower = factionPower.add(getPlayerPower(UUID.fromString(faction.Leader)));
+       // }
+//
+       // if(faction.Officers != null && !faction.Officers.isEmpty())
+       // {
+       //     for (String officer: faction.Officers)
+       //     {
+       //         BigDecimal officerPower = getPlayerPower(UUID.fromString(officer));
+       //         factionPower =factionPower.add(officerPower);
+       //     }
+       // }
+//
+       // if(faction.Members != null && !faction.Members.isEmpty())
+       // {
+       //     for (String member: faction.Members)
+       //     {
+       //         BigDecimal memberPower = getPlayerPower(UUID.fromString(member));
+       //         factionPower = factionPower.add(memberPower);
+       //     }
+       // }
         return factionPower;
     }
 

--- a/src/main/java/io/github/aquerr/eaglefactions/services/PowerService.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/services/PowerService.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -305,6 +306,25 @@ public class PowerService
                 playerNode.getNode("power").setValue(0.0);
             }
 
+            configLoader.save(playerNode);
+        }
+        catch (Exception exception)
+        {
+            exception.printStackTrace();
+        }
+    }
+
+    public static void setMaxPower(UUID playerUUID, BigDecimal power)
+    {
+        Path playerFile = Paths.get(EagleFactions.getEagleFactions ().getConfigDir().resolve("players") +  "/" + playerUUID.toString() + ".conf");
+
+        try
+        {
+            ConfigurationLoader<CommentedConfigurationNode> configLoader = HoconConfigurationLoader.builder().setPath(playerFile).build();
+
+            CommentedConfigurationNode playerNode = configLoader.load();
+
+            playerNode.getNode("maxpower").setValue(power);
             configLoader.save(playerNode);
         }
         catch (Exception exception)

--- a/src/main/java/io/github/aquerr/eaglefactions/services/PowerService.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/services/PowerService.java
@@ -12,6 +12,7 @@ import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.scheduler.AsynchronousExecutor;
 import org.spongepowered.api.scheduler.Task;
+import sun.applet.Main;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -269,6 +270,37 @@ public class PowerService
         else
         {
             PowerService.setPower(playerUUID, BigDecimal.ZERO);
+        }
+    }
+
+    public static void punish(UUID playerUUID)
+    {
+        Path playerFile = Paths.get(EagleFactions.getEagleFactions ().getConfigDir().resolve("players") +  "/" + playerUUID.toString() + ".conf");
+
+        try
+        {
+            ConfigurationLoader<CommentedConfigurationNode> configLoader = HoconConfigurationLoader.builder().setPath(playerFile).build();
+
+            CommentedConfigurationNode playerNode = configLoader.load();
+
+            BigDecimal playerPower = new BigDecimal(playerNode.getNode("power").getString());
+
+            BigDecimal punishment = MainLogic.getPunishment();
+
+            if(playerPower.doubleValue() - punishment.doubleValue() > 0)
+            {
+                playerNode.getNode("power").setValue(playerPower.subtract(punishment));
+            }
+            else
+            {
+                playerNode.getNode("power").setValue(0.0);
+            }
+
+            configLoader.save(playerNode);
+        }
+        catch (Exception exception)
+        {
+            exception.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
Hello,

Please add node permission for modify terrain on safezone and warzone  and only that !
Lot of serveurs have builders and dont want it to have access to /f admin command.

And other, i try to add customnpcs in safezone and it's not possible with /f admin enabled !

Thanks for read this