### PR TITLE
Dynmap Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check our [Wiki](https://github.com/Aquerr/EagleFactions/wiki) to get to know ho
 * PVP-Logger
 * Plugin Messages' Translations
 * Database support
+^ Dynmap support
 * Fully configurable
 
 ## Translations

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 //    compile group: 'io.github.webbukkit', name: 'DynmapCoreAPI', version: '2.1'
 //    compile 'com.github.webbukkit:DynmapCoreAPI:v2.5'
     compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.16'
-    compile name: "Dynmap-3.0-beta-1-forge-1.12.2"
+    compile 'com.github.webbukkit:DynmapCoreAPI:v2.5'
     //compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.7.2'
 //    compile 'org.mariadb.jdbc:mariadb-java-client:2.0.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,6 @@ allprojects {
     }
 }
 
-repositories {
-    flatDir {
-        dirs 'libs'
-    }
-}
-
 dependencies {
     compile 'org.spongepowered:spongeapi:7.1.0'
     compile 'com.github.rojo8399:PlaceholderAPI:4.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@ allprojects {
     }
 }
 
+repositories {
+    flatDir {
+        dirs 'libs'
+    }
+}
+
 dependencies {
     compile 'org.spongepowered:spongeapi:7.1.0'
     compile 'com.github.rojo8399:PlaceholderAPI:4.5.1'
@@ -24,6 +30,7 @@ dependencies {
 //    compile group: 'io.github.webbukkit', name: 'DynmapCoreAPI', version: '2.1'
 //    compile 'com.github.webbukkit:DynmapCoreAPI:v2.5'
     compile group: 'mysql', name: 'mysql-connector-java', version: '8.0.16'
+    compile name: "Dynmap-3.0-beta-1-forge-1.12.2"
     //compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.7.2'
 //    compile 'org.mariadb.jdbc:mariadb-java-client:2.0.3'
 }

--- a/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import io.github.aquerr.eaglefactions.commands.*;
 import io.github.aquerr.eaglefactions.config.Configuration;
 import io.github.aquerr.eaglefactions.config.IConfiguration;
+import io.github.aquerr.eaglefactions.dynmap.DynmapMain;
 import io.github.aquerr.eaglefactions.entities.*;
 import io.github.aquerr.eaglefactions.listeners.*;
 import io.github.aquerr.eaglefactions.logic.AttackLogic;
@@ -151,6 +152,15 @@ public class EagleFactions
         if(permissionService.isPresent())
         {
             permissionService.get().getDefaults().getSubjectData().setPermission(SubjectData.GLOBAL_CONTEXT, "eaglefactions.player", Tristate.TRUE);
+        }
+
+        try {
+            Class.forName("org.dynmap.DynmapCommonAPI");
+            DynmapMain.activate();
+
+            printInfo("Dynmap integration is active!");
+        } catch (ClassNotFoundException error) {
+            printInfo("Dynmap is not installed, but integration is enabled in the config.");
         }
     }
 

--- a/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/EagleFactions.java
@@ -2,6 +2,7 @@ package io.github.aquerr.eaglefactions;
 
 import com.google.inject.Inject;
 import io.github.aquerr.eaglefactions.commands.*;
+import io.github.aquerr.eaglefactions.config.ConfigFields;
 import io.github.aquerr.eaglefactions.config.Configuration;
 import io.github.aquerr.eaglefactions.config.IConfiguration;
 import io.github.aquerr.eaglefactions.dynmap.DynmapMain;
@@ -154,13 +155,15 @@ public class EagleFactions
             permissionService.get().getDefaults().getSubjectData().setPermission(SubjectData.GLOBAL_CONTEXT, "eaglefactions.player", Tristate.TRUE);
         }
 
-        try {
-            Class.forName("org.dynmap.DynmapCommonAPI");
-            DynmapMain.activate();
+        if (_configuration.getConfigFields().isDynmapIntegrationEnabled()) {
+            try {
+                Class.forName("org.dynmap.DynmapCommonAPI");
+                DynmapMain.activate();
 
-            printInfo("Dynmap integration is active!");
-        } catch (ClassNotFoundException error) {
-            printInfo("Dynmap is not installed, but integration is enabled in the config.");
+                printInfo("Dynmap Integration is active!");
+            } catch (ClassNotFoundException error) {
+                printInfo("Failed to enable Dynmap Integration; Dynmap is not available");
+            }
         }
     }
 

--- a/src/main/java/io/github/aquerr/eaglefactions/config/ConfigFields.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/config/ConfigFields.java
@@ -92,6 +92,17 @@ public final class ConfigFields
     //Chat
     private boolean _supressOtherFactionsMessagesWhileInTeamChat = false;
 
+    //Dynmap Integration
+    private boolean _dynmapIntegrationEnabled = false;
+
+    private int _dynmapFactionColor = 0x00FF00;
+    private int _dynmapSafezoneColor = 0x800080;
+    private int _dynmapWarzoneColor = 0xFF0000;
+    private String _dynmapFactionHomeIcon = "greenflag";
+
+    private boolean _dynmapShowFactionLeader = true;
+    private boolean _dynmapMemberInfo = true;
+
     public ConfigFields(IConfiguration configuration)
     {
         _configuration = configuration;
@@ -183,6 +194,17 @@ public final class ConfigFields
 
             //Chat
             this._supressOtherFactionsMessagesWhileInTeamChat = _configuration.getBoolean(false, "suppress-other-factions-messages-while-in-team-chat");
+
+            //Dynmap Integration
+            this._dynmapIntegrationEnabled = _configuration.getBoolean(false, "dynmap-integration-enable");
+
+            this._dynmapFactionColor = _configuration.getInt(0x00FF00, "dynmap-faction-color");
+            this._dynmapSafezoneColor = _configuration.getInt(0x800080, "dynmap-safezone-color");
+            this._dynmapWarzoneColor = _configuration.getInt(0xFF0000, "dynmap-warzone-color");
+            this._dynmapFactionHomeIcon = _configuration.getString("greenflag", "dynmap-faction-home-marker");
+
+            this._dynmapShowFactionLeader = _configuration.getBoolean(true, "dynmap-show-faction-leader");
+            this._dynmapMemberInfo = _configuration.getBoolean(true, "dynmap-members-info");
 
             this._configuration.save();
         }
@@ -600,5 +622,34 @@ public final class ConfigFields
     public boolean shouldSupressOtherFactionsMessagesWhileInTeamChat()
     {
         return this._supressOtherFactionsMessagesWhileInTeamChat;
+    }
+
+    // Dynmap Integration
+    public boolean isDynmapIntegrationEnabled() {
+        return this._dynmapIntegrationEnabled;
+    }
+
+    public int getDynmapFactionColor() {
+        return this._dynmapFactionColor;
+    }
+
+    public int getDynmapSafezoneColor() {
+        return this._dynmapSafezoneColor;
+    }
+
+    public int getDynmapWarzoneColor() {
+        return this._dynmapWarzoneColor;
+    }
+
+    public String getDynmapFactionHomeIcon() {
+        return this._dynmapFactionHomeIcon;
+    }
+
+    public boolean showDynmapFactionLeader() {
+        return this._dynmapShowFactionLeader;
+    }
+
+    public boolean showDynmapMemberInfo() {
+        return this._dynmapMemberInfo;
     }
 }

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapMain.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapMain.java
@@ -4,20 +4,25 @@ import io.github.aquerr.eaglefactions.EagleFactions;
 import org.dynmap.DynmapCommonAPI;
 import org.dynmap.DynmapCommonAPIListener;
 import org.dynmap.markers.MarkerAPI;
-import org.spongepowered.api.Sponge;
+import org.dynmap.markers.MarkerSet;
 import org.spongepowered.api.scheduler.Task;
-
 import java.util.concurrent.TimeUnit;
+
+/**
+ * Main Dynmap Integration class, contains Dynmap API fields and activate void
+ * @author Iterator
+ */
 
 public class DynmapMain {
     static MarkerAPI markerapi;
-
+    static MarkerSet markerSet;
 
     public static void activate() {
         DynmapCommonAPIListener.register(new DynmapCommonAPIListener() {
             @Override
             public void apiEnabled(DynmapCommonAPI api) {
                 markerapi = api.getMarkerAPI();
+                markerSet = DynmapMain.markerapi.createMarkerSet("purpleflag", "EagleFactions", DynmapMain.markerapi.getMarkerIcons(), false);
 
                 Task.builder().execute(new DynmapUpdateTask())
                         .interval(10, TimeUnit.SECONDS)

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapMain.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapMain.java
@@ -1,0 +1,29 @@
+package io.github.aquerr.eaglefactions.dynmap;
+
+import io.github.aquerr.eaglefactions.EagleFactions;
+import org.dynmap.DynmapCommonAPI;
+import org.dynmap.DynmapCommonAPIListener;
+import org.dynmap.markers.MarkerAPI;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.scheduler.Task;
+
+import java.util.concurrent.TimeUnit;
+
+public class DynmapMain {
+    static MarkerAPI markerapi;
+
+
+    public static void activate() {
+        DynmapCommonAPIListener.register(new DynmapCommonAPIListener() {
+            @Override
+            public void apiEnabled(DynmapCommonAPI api) {
+                markerapi = api.getMarkerAPI();
+
+                Task.builder().execute(new DynmapUpdateTask())
+                        .interval(10, TimeUnit.SECONDS)
+                        .name("EagleFactions Dynmap Update Task")
+                        .submit(EagleFactions.getPlugin());
+            }
+        });
+    }
+}

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
@@ -1,0 +1,28 @@
+package io.github.aquerr.eaglefactions.dynmap;
+
+import org.dynmap.markers.AreaMarker;
+import org.dynmap.markers.MarkerSet;
+import org.spongepowered.api.Sponge;
+
+public class DynmapUpdateTask implements Runnable {
+    @Override
+    public void run() {
+        // TODO: add optimizations
+        if (!Sponge.getServer().getDefaultWorld().isPresent()) {
+            return;
+        }
+
+        String worldName = Sponge.getServer().getDefaultWorld().get().getWorldName();
+
+        MarkerSet markerSwt = DynmapMain.markerapi.createMarkerSet("test_markerset", "EagleFactions", DynmapMain.markerapi.getMarkerIcons(), false);
+        String markerId = worldName + "_" + "FactionTest";
+
+        AreaMarker areaMarker = markerSwt.createAreaMarker(markerId, "FactionTest", false, worldName, new double[3000], new double[1000], false);
+
+        areaMarker.setCornerLocation(0, 0, 0);
+        areaMarker.setCornerLocation(1, -100, -100);
+
+        areaMarker.setLabel("Test");
+        areaMarker.setDescription("Test?");
+    }
+}

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
@@ -14,13 +14,15 @@ public class DynmapUpdateTask implements Runnable {
 
         String worldName = Sponge.getServer().getDefaultWorld().get().getWorldName();
 
-        MarkerSet markerSwt = DynmapMain.markerapi.createMarkerSet("islandearth.markerset", "EagleFactions", DynmapMain.markerapi.getMarkerIcons(), false);
+        MarkerSet markerSwt = DynmapMain.markerapi.createMarkerSet("purpleflag", "EagleFactions", DynmapMain.markerapi.getMarkerIcons(), false);
         String markerId = worldName + "_" + "FactionTest";
 
-        AreaMarker areaMarker = markerSwt.createAreaMarker(markerId, "FactionTest", false, worldName, new double[3000], new double[1000], false);
+        AreaMarker areaMarker = markerSwt.createAreaMarker(markerId, "FactionTest", false, worldName, new double[1000], new double[1000], false);
 
-        areaMarker.setCornerLocation(0, 0, 0);
-        areaMarker.setCornerLocation(1, -100, -100);
+        double[] d1 = {-50, -9};
+        double[] d2 = {-720, -679};
+
+        areaMarker.setCornerLocations(d1, d2);
 
         areaMarker.setLabel("Test");
         areaMarker.setDescription("Test?");

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
@@ -1,30 +1,134 @@
 package io.github.aquerr.eaglefactions.dynmap;
 
+import com.flowpowered.math.vector.Vector3i;
+import io.github.aquerr.eaglefactions.EagleFactions;
+import io.github.aquerr.eaglefactions.dynmap.util.DynmapUtils;
+import io.github.aquerr.eaglefactions.dynmap.util.TempAreaMarker;
+import io.github.aquerr.eaglefactions.entities.Claim;
+import io.github.aquerr.eaglefactions.entities.Faction;
 import org.dynmap.markers.AreaMarker;
-import org.dynmap.markers.MarkerSet;
+import org.dynmap.markers.Marker;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.world.World;
+import java.util.*;
+
+/**
+ * Dynmap Integration update task. It draws the faction areas by scanning all factions.
+ * It stores the factions and compares new ones to the old ones when updating, and if they're different updates them.
+ *
+ * @author Iterator
+ */
 
 public class DynmapUpdateTask implements Runnable {
+    private ArrayList<Faction> drawnFactions = new ArrayList<>();
+
+    private HashMap<String, Marker> drawnMarkers = new HashMap<>();
+    private HashMap<String, ArrayList<AreaMarker>> drawnAreas = new HashMap<>();
+
     @Override
     public void run() {
-        // TODO: add optimizations
-        if (!Sponge.getServer().getDefaultWorld().isPresent()) {
-            return;
+        for (Iterator<Faction> iterator = drawnFactions.iterator(); iterator.hasNext();) {
+            Faction drawmFaction = iterator.next();
+
+            Faction currentFaction = EagleFactions.getPlugin().getFactionLogic().getFactionByName(drawmFaction.getName());
+
+            if (currentFaction == null || !currentFaction.equals(drawmFaction)) {
+                /* Remove everything created */
+                if (drawnMarkers.get(drawmFaction.getName()) != null) {
+                    drawnMarkers.get(drawmFaction.getName()).deleteMarker();
+                    drawnMarkers.remove(drawmFaction.getName());
+                }
+
+                if (drawnAreas.get(drawmFaction.getName()) != null) {
+                    for (AreaMarker drawFactionArea : drawnAreas.get(drawmFaction.getName())) {
+                        drawFactionArea.deleteMarker();
+                    }
+
+                    drawnAreas.remove(drawmFaction.getName());
+                }
+
+                /* Mark the faction for update */
+                iterator.remove();
+            }
         }
 
-        String worldName = Sponge.getServer().getDefaultWorld().get().getWorldName();
+        for (Faction faction : new HashSet<>(EagleFactions.getPlugin().getFactionLogic().getFactions().values())) {
+            if (faction.getClaims().size() < 1 || drawnFactions.contains(faction)) continue; /* Faction does not have any claims or it's already drawn */
 
-        MarkerSet markerSwt = DynmapMain.markerapi.createMarkerSet("purpleflag", "EagleFactions", DynmapMain.markerapi.getMarkerIcons(), false);
-        String markerId = worldName + "_" + "FactionTest";
+            if (faction.getHome() != null) { /* Let's draw faction home first */
+                World factionHomeWorld = Sponge.getServer().getWorld(faction.getHome().getWorldUUID()).isPresent()
+                        ? Sponge.getServer().getWorld(faction.getHome().getWorldUUID()).get()
+                        : null;
 
-        AreaMarker areaMarker = markerSwt.createAreaMarker(markerId, "FactionTest", false, worldName, new double[1000], new double[1000], false);
+                if (factionHomeWorld != null) {
+                    Vector3i blockPos = faction.getHome().getBlockPosition();
 
-        double[] d1 = {-50, -9};
-        double[] d2 = {-720, -679};
+                    Marker marker = DynmapMain.markerSet.createMarker(null,
+                            faction.getName() + " Home",
+                            factionHomeWorld.getName(),
+                            blockPos.getX(),
+                            blockPos.getY(),
+                            blockPos.getZ(),
+                            DynmapMain.markerapi.getMarkerIcon(EagleFactions.getPlugin().getConfiguration().getConfigFields().getDynmapFactionHomeIcon()),
+                            false);
 
-        areaMarker.setCornerLocations(d1, d2);
+                    drawnMarkers.put(faction.getName(), marker);
+                }
+            }
 
-        areaMarker.setLabel("Test");
-        areaMarker.setDescription("Test?");
+            /*
+            Code below may not be very clean. BUT IT WORKS!
+             */
+
+            HashMap<UUID, Set<Claim>> claimsWorld = new HashMap<>();
+
+            /* Now sorting the claims by their worlds */
+            Claim[] claims = new Claim[faction.getClaims().size()];
+            claims = faction.getClaims().toArray(claims);
+            for (Claim claim : claims) {
+                claimsWorld.computeIfAbsent(claim.getWorldUUID(), k -> new HashSet<>());
+
+                claimsWorld.get(claim.getWorldUUID()).add(claim);
+            }
+
+            /* Now making TempAreaMarkers */
+            HashMap<UUID, ArrayList<TempAreaMarker>> areaMarkers = new HashMap<>();
+            claimsWorld.forEach((k, v) -> {
+                ArrayList<TempAreaMarker> tempMarkers = DynmapUtils.createAreas(v);
+
+                areaMarkers.put(k, tempMarkers);
+            });
+
+            /* Finally, lets draw areas! */
+            drawnAreas.put(faction.getName(), new ArrayList<>());
+
+            for (Map.Entry<UUID, ArrayList<TempAreaMarker>> entry : areaMarkers.entrySet()) {
+                for (TempAreaMarker tempMarker : entry.getValue()) {
+                    World world = Sponge.getServer().getWorld(entry.getKey()).isPresent() ? Sponge.getServer().getWorld(entry.getKey()).get() : null;
+
+                    if (world == null) continue; /* Somehow there's no world for that area */
+
+                    AreaMarker areaMarker = DynmapMain.markerSet.createAreaMarker(null,
+                            faction.getName(),
+                            false,
+                            world.getName(),
+                            new double[1000],
+                            new double[1000],
+                            false);
+
+                    areaMarker.setDescription(DynmapUtils.getFactionInfoWindow(faction));
+
+                    int areaColor = DynmapUtils.getAreaColor(faction);
+                    areaMarker.setLineStyle(3, 0.8, areaColor);
+                    areaMarker.setFillStyle(0.35, areaColor);
+
+                    areaMarker.setCornerLocations(tempMarker.x, tempMarker.z);
+
+                    drawnAreas.get(faction.getName()).add(areaMarker);
+                }
+            }
+
+            drawnFactions.add(faction);
+        }
     }
 }

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/DynmapUpdateTask.java
@@ -14,7 +14,7 @@ public class DynmapUpdateTask implements Runnable {
 
         String worldName = Sponge.getServer().getDefaultWorld().get().getWorldName();
 
-        MarkerSet markerSwt = DynmapMain.markerapi.createMarkerSet("test_markerset", "EagleFactions", DynmapMain.markerapi.getMarkerIcons(), false);
+        MarkerSet markerSwt = DynmapMain.markerapi.createMarkerSet("islandearth.markerset", "EagleFactions", DynmapMain.markerapi.getMarkerIcons(), false);
         String markerId = worldName + "_" + "FactionTest";
 
         AreaMarker areaMarker = markerSwt.createAreaMarker(markerId, "FactionTest", false, worldName, new double[3000], new double[1000], false);

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/DynmapUtils.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/DynmapUtils.java
@@ -30,7 +30,7 @@ public class DynmapUtils {
                 "<span style=\"font-weight: bold; font-size: 150%;\">%name%</span></br>\n".replace("%name%", factionName) +
                 "<span style=\"font-style: italic; font-size: 110%;\">%description%</span></br>\n".replace("%description%", factionDesc.length() > 0 ? factionDesc : "No description"));
 
-        if (faction.getTag() != null) {
+        if (faction.getTag().toPlain().length() > 0) {
             description.append("<span style=\"font-weight: bold;\">Tag:</span> %tag%</br>\n".replace("%tag%", faction.getTag().toPlain()) +
                     "</br>\n");
         }

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/DynmapUtils.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/DynmapUtils.java
@@ -28,13 +28,11 @@ public class DynmapUtils {
 
         description.append("<div class=\"infowindow\">\n" +
                 "<span style=\"font-weight: bold; font-size: 150%;\">%name%</span></br>\n".replace("%name%", factionName) +
-                "<span style=\"font-style: italic; font-size: 110%;\">%description%</span></br>\n".replace("%description%", factionDesc.length() > 0 ? factionDesc : "No description") +
-                "</br>\n");
+                "<span style=\"font-style: italic; font-size: 110%;\">%description%</span></br>\n".replace("%description%", factionDesc.length() > 0 ? factionDesc : "No description"));
 
         if (faction.getTag() != null) {
-            description.append("\"<span style=\\\"font-weight: bold;\\\">Tag:</span> %tag%</br>\\n\"" +
-                    "</br>\n"
-                            .replace("%tag%", faction.getTag().toPlain()));
+            description.append("<span style=\"font-weight: bold;\">Tag:</span> %tag%</br>\n".replace("%tag%", faction.getTag().toPlain()) +
+                    "</br>\n");
         }
 
         if (config.showDynmapFactionLeader() && userStorage.isPresent()) {

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/DynmapUtils.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/DynmapUtils.java
@@ -6,6 +6,7 @@ import io.github.aquerr.eaglefactions.entities.Claim;
 import io.github.aquerr.eaglefactions.entities.Faction;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.service.user.UserStorageService;
+
 import java.util.*;
 
 /**
@@ -83,9 +84,8 @@ public class DynmapUtils {
      *
      */
 
-    static void floodFillTarget(TileFlags source, TileFlags destination, int x, int y)
+    private static void floodFillTarget(TileFlags source, TileFlags destination, int x, int y)
     {
-        int cnt = 0;
         ArrayDeque<int[]> stack = new ArrayDeque<int[]>();
         stack.push(new int[] { x, y });
 
@@ -98,7 +98,6 @@ public class DynmapUtils {
             { // Set in src
                 source.setFlag(x, y, false); // Clear source
                 destination.setFlag(x, y, true); // Set in destination
-                cnt++;
                 if (source.getFlag(x + 1, y)) stack.push(new int[] { x + 1, y });
                 if (source.getFlag(x - 1, y)) stack.push(new int[] { x - 1, y });
                 if (source.getFlag(x, y + 1)) stack.push(new int[] { x, y + 1 });

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/TempAreaMarker.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/TempAreaMarker.java
@@ -1,0 +1,11 @@
+package io.github.aquerr.eaglefactions.dynmap.util;
+
+public class TempAreaMarker {
+    public double[] x;
+    public double[] z;
+
+    TempAreaMarker(double[] x, double[] z) {
+        this.x = x;
+        this.z = z;
+    }
+}

--- a/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/TileFlags.java
+++ b/src/main/java/io/github/aquerr/eaglefactions/dynmap/util/TileFlags.java
@@ -1,0 +1,68 @@
+package io.github.aquerr.eaglefactions.dynmap.util;
+
+import java.util.HashMap;
+
+/**
+ * scalable flags primitive - used for keeping track of potentially huge number of tiles
+ *
+ * Represents a flag for each tile, with 2D coordinates based on 0,0 origin.  Flags are grouped
+ * 64 x 64, represented by an array of 64 longs.  Each set is stored in a hashmap, keyed by a long
+ * computed by ((x/64)<<32)+(y/64).
+ *
+ * @author Webbukkit team
+ */
+public class TileFlags {
+    private HashMap<Long, long[]> chunkmap = new HashMap<Long, long[]>();
+    private long last_key = Long.MAX_VALUE;
+    private long[] last_row;
+
+    TileFlags() {
+    }
+
+    boolean getFlag(int x, int y) {
+        long k = (((long)(x >> 6)) << 32) | (0xFFFFFFFFL & (long)(y >> 6));
+        long[] row;
+        if(k == last_key) {
+            row = last_row;
+        }
+        else {
+            row = chunkmap.get(k);
+            last_key = k;
+            last_row = row;
+        }
+        if(row == null)
+            return false;
+        else
+            return (row[y & 0x3F] & (1L << (x & 0x3F))) != 0;
+    }
+
+    void setFlag(int x, int y, boolean f) {
+        long k = (((long)(x >> 6)) << 32) | (0xFFFFFFFFL & (long)(y >> 6));
+        long[] row;
+        if(k == last_key) {
+            row = last_row;
+        }
+        else {
+            row = chunkmap.get(k);
+            last_key = k;
+            last_row = row;
+        }
+        if(f) {
+            if(row == null) {
+                row = new long[64];
+                chunkmap.put(k, row);
+                last_row = row;
+            }
+            row[y & 0x3F] |= (1L << (x & 0x3F));
+        }
+        else {
+            if(row != null)
+                row[y & 0x3F] &= ~(1L << (x & 0x3F));
+        }
+    }
+    public void clear() {
+        chunkmap.clear();
+        last_row = null;
+        last_key = Long.MAX_VALUE;
+    }
+}

--- a/src/main/resources/Settings.conf
+++ b/src/main/resources/Settings.conf
@@ -294,3 +294,24 @@ block-home-after-death-in-own-faction {
     toggled=false
     time=60
 }
+
+#######################################################
+#                                                     #
+#                  Dynmap Integration                 #
+#                                                     #
+#######################################################
+
+# Enables Dynmap Integration
+dynmap-integration-enable=true
+
+#Color of faction that isn't Safe or War zone.
+dynmap-faction-color=0
+
+#Color of SafeZone faction
+dynmap-safezone-color=t0
+
+#Color of WarZone faction
+dynmap-warzone-color=0
+
+#Show info about faction members in textbox
+dynmap-members-info=true

--- a/src/main/resources/Settings.conf
+++ b/src/main/resources/Settings.conf
@@ -301,17 +301,30 @@ block-home-after-death-in-own-faction {
 #                                                     #
 #######################################################
 
+### Generic
+
 # Enables Dynmap Integration
-dynmap-integration-enable=true
+dynmap-integration-enable=false
 
-#Color of faction that isn't Safe or War zone.
-dynmap-faction-color=0
+### Customization (you can pick the colors on HEX color pciker)
 
-#Color of SafeZone faction
-dynmap-safezone-color=t0
+# Color of faction that isn't Safe or War zone
+dynmap-faction-color=0x00FF00
 
-#Color of WarZone faction
-dynmap-warzone-color=0
+# Color of SafeZone faction
+dynmap-safezone-color=0x800080
 
-#Show info about faction members in textbox
+# Color of WarZone faction
+dynmap-warzone-color=0xFF0000
+
+# Icon of the faction home marker. Full icon list is located at
+# https://github.com/webbukkit/DynmapCore/blob/master/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java#L65-L74
+dynmap-faction-home-marker="greenflag"
+
+### Factions privacy (Information showed in faction description showed in an infowindow)
+
+# Shows the faction's leader
+dynmap-show-faction-leader=true
+
+# Shows info about faction members
 dynmap-members-info=true


### PR DESCRIPTION
Yes, it is exactly what title says.
It will make all faction claims and faction homes visible on Dynmap as it was requested in #25.
It also provides a nice description about the faction when you click on its area.

# How does it look
![EF_PR](https://user-images.githubusercontent.com/30198566/61076454-ba759200-a435-11e9-818f-d3386052278f.png)

# How does it work
When Dynmap is started, it submits a new "Update Task" that runs every 10 seconds.
In this task, it's checking for faction updates and redraws everyting for the updated one.

# New Setting.conf nodes

- dynmap-integration-enable [default:false] - enables or disables Dynmap Integration
- dynmap-faction-color [default:0x00FF00] - area color for typical faction that is not Safe or War zone
- dynmap-safezone-color [default:0x800080] - area color for SafeZone
- dynmap-warzone-color [default:0xFF0000] - area color for WarZone